### PR TITLE
Add spec text to be compatible with WebCrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 # Cryptographically Secure Pseudo-Random Number Generation (CSPRNG) for ECMAScript
 
 This proposes the addition of a user-addressable function that can be used to fill the 
-portion of an `ArrayBuffer` associated with a `TypedArray` or `DataView` with cryptographically secure pseudo-random number values.
+portion of an `ArrayBuffer` associated with a `TypedArray` with cryptographically secure pseudo-random number values.
 
-Portions of this proposal are derived from the [Web Cryptography API](https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues)
+Portions of this proposal are derived from the [Web Cryptography API][WebCrypto]:
+
+> The [Web Cryptography API][WebCrypto] is Copyright &#xA9; 2018 [World Wide Web Consortium](http://www.w3.org/), ([MIT](http://www.csail.mit.edu/), 
+[ERCIM](http://www.ercim.org/), [Keio](http://www.keio.ac.jp/), [Beihang](http://ev.buaa.edu.cn/)). http://www.w3.org/Consortium/Legal/2015/doc-license
+>
+> The [Web Cryptography API][WebCrypto] is an Editors Draft, per the [February 2018 W3C Process Document](https://www.w3.org/2018/Process-20180201/).
+
 <!--#endregion:intro-->
 
 <!--#region:status-->
@@ -13,7 +19,7 @@ Portions of this proposal are derived from the [Web Cryptography API](https://w3
 **Stage:** 1  
 **Champion:** Ron Buckton (@rbuckton)  
 
-_For detailed status of this proposal see [TODO](#todo), below._  
+_For detailed status of this proposal see [TODO][], below._  
 <!--#endregion:status-->
 
 <!--#region:authors-->
@@ -28,13 +34,13 @@ _For detailed status of this proposal see [TODO](#todo), below._
 One of the [key issues](https://github.com/tc39/proposal-uuid/issues/37) for https://github.com/tc39/proposal-uuid is the lack
 of a "source of truth" for cryptographically secure pseudo-random numbers within the ECMAScript language. While hosts such as 
 browsers and NodeJS provide implementations of CSPRNGs (Cryptographically Secure Pseudo-Random Number Generators), the ECMAScript
-language itself has no mechanism for supplying a CSPRNG that can be used by proposed APIs such as [UUID](https://github.com/tc39/proposal-uuid).
+language itself has no mechanism for supplying a CSPRNG that can be used by proposed APIs such as [UUID][].
 
 ### Goals
 
-* Provide a single "source of truth" for generating cryptographically secure pseudo-random values within the language.
+* Provide a single "source of truth" for generating cryptographically secure pseudo-random number values within the language.
 * Provide a single location for mocking the CSPRNG, vs a method on each `TypedArray` prototype.
-* If introducing a new `crypto` global namespace for cryptography-related APIs in ECMA-262, we should ensure that the Web cryptography APIs could be layered on top.
+* If introducing a new `crypto` global namespace for cryptography-related APIs in ECMA-262, we should ensure that the Web Cryptography APIs could be layered on top.
 <!--#endregion:motivations-->
 
 <!--#region:prior-art-->
@@ -64,44 +70,56 @@ language itself has no mechanism for supplying a CSPRNG that can be used by prop
 <!--#endregion:semantics-->
 
 <!--#region:examples-->
-<!--
 # Examples
 
-> TODO: Provide examples of the proposal.
+```js
+const array = new Uint8Array(16);
+crypto.getRandomValues(array); // returns `array`
+```
 
--->
 <!--#endregion:examples-->
 
 <!--#region:api-->
 # API
 
-We are still investigating the API surface area for this proposal. The intended API would be a user-addressable function that when called executes the [FillRandomValues](#fillrandomvalues-view) abstract operation, below.
+# The `crypto` Object
 
-The Stage 0 API proposal exposed this as a static `ArrayBuffer.fillRandom` method, although we are continuing to investigate this space.
+This proposal introduces a global `crypto` object that is intended to be compatible with the implementation in the [Web Cryptography API][WebCrypto]. 
+As such, the global `crypto` object is defined as being a reference to a built-in %crypto% object, which in turn has its \[\[Prototype]] internal slot that points to a built-in %CryptoPrototype% object to which API methods are attached. This is intended to preserve the prototype hierarchy inherent in the WebIDL
+definition for the [Crypto interface](https://w3c.github.io/webcrypto/#crypto-interface). 
 
-# Abstract Operations
+To support spec layering with the Web Cryptography API, WebIDL attributes like `subtle` can be defined by a host to exist on the %crypto% built-in object, and additional members of the Crypto interface could be defined on the %CryptoPrototype% built-in object.
 
-## FillRandomValues (view)
+## Properties of the %CryptoPrototype% object
 
-When abstract operation FillRandomValues is called with argument _view_, the following steps are taken:
+The %CryptoPrototype% object is intended to represent the minimal subset of the [Crypto interface](https://w3c.github.io/webcrypto/#crypto-interface) from the [Web Cryptography API][WebCrypto] necessary to implement this proposal. This would allow the Web Cryptography API to layer its implementation on top of the specification in this proposal in a web-compatible
+way.
 
-1. Perform ? RequireInternalSlot(_view_, \[\[TypedArrayName]]).
-1. Assert: _view_ has the \[\[ViewedArrayBuffer]], \[\[ByteLength]], and \[\[ByteOffset\]\] internal slots.
-1. If _view_.\[\[TypedArrayName]] is not one of `"Int8Array"`, `"Uint8Array"`, `"Uint8ClampedArray"`, `"Int16Array"`, `"Uint16Array"`, `"Int32Array"`, `"Uint32Array"`, `"BigInt64Array"`, or `"BigUint64Array"`, throw a **TypeError** exception.
-1. Let _buffer_ be _view_.\[\[ViewedArrayBuffer]].
+### %CryptoPrototype%.getRandomValues ( array )
+
+When getRandomValues is called with argument _array_, the following steps are taken:
+
+1. Perform ? RequireInternalSlot(_array_, \[\[TypedArrayName]]).
+1. Assert: _array_ has the \[\[ViewedArrayBuffer]], \[\[ByteLength]], and \[\[ByteOffset\]\] internal slots.
+1. If _array_.\[\[TypedArrayName]] is not one of `"Int8Array"`, `"Uint8Array"`, `"Uint8ClampedArray"`, `"Int16Array"`, `"Uint16Array"`, `"Int32Array"`, `"Uint32Array"`, `"BigInt64Array"`, or `"BigUint64Array"`, throw a **TypeError** exception.
+1. Let _buffer_ be _array_.\[\[ViewedArrayBuffer]].
 1. If ! IsDetachedBuffer(_buffer_) is **true**, throw a **TypeError** exception.
-1. Let _byteLength_ be _view_.\[\[ByteLength]].
+1. Let _byteLength_ be _array_.\[\[ByteLength]].
 1. If _byteLength_ is greater than 65536, throw a **RangeError** exception.
-1. Let _byteOffset_ be _view_.\[\[ByteOffset]].
+1. Let _byteOffset_ be _array_.\[\[ByteOffset]].
 1. Let _byteEndOffset_ be _byteOffset_ + _byteLength_.
 1. Overwrite the elements of _buffer_ from index _byteOffset_ (inclusive) through index _byteEndOffset_ (exclusive) with cryptographically secure random values.
-1. Return _view_.
+1. Return _array_.
 
 > **Note**  
 > Implementations should generate cryptographically secure random values using well-established cryptographic pseudo-random number generators seeded with high-quality entropy, such as from an operating-system entropy source (e.g., "/dev/urandom"). This specification provides no lower-bound on the information theoretic entropy present in cryptographically secure random values, but implementations should make a best effort to provide as much entropy as practicable.
 
 > **Note**  
 > This interface defines a synchronous method for obtaining cryptographically secure random values. While some devices and implementations may support truly random cryptographic number generators or provide interfaces that block when there is insufficient entropy, implementations are discouraged from using these sources when implementing getRandomValues, both for performance and to avoid depleting the system of entropy. Instead, these sources should be used to seed a cryptographic pseudo-random number generator that can then return suitable values efficiently.
+
+### %CryptoPrototype% [ @@toStringTag ]
+
+The initial value of the \@\@toStringTag property of %CryptoPrototype% is the String value `"Crypto"`.
 <!--#endregion:api-->
 
 <!--#region:grammar-->
@@ -119,15 +137,16 @@ When abstract operation FillRandomValues is called with argument _view_, the fol
 <!--#region:references-->
 # References
 
-* [Web Cryptography API](https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues)
-* [UUID Proposal](https://github.com/tc39/proposal-uuid)
-* [Original Strawman](https://gist.github.com/rbuckton/0777210dc3086e1a90375354b045a3a7)  
+* [Web Cryptography API][WebCrypto] ([GitHub](https://github.com/w3c/webcrypto))
+* [UUID Proposal][UUID]  
 <!--#endregion:references-->
 
 <!--#region:prior-discussion-->
 # Prior Discussion
 
 * *Separate proposal for CSPRNG "source of truth"*: https://github.com/tc39/proposal-uuid/issues/37  
+* *Math.urandom() in ECMAScript*: https://github.com/tc39/proposal-uuid/issues/31
+* *Using Math.getRandomValues()*: https://github.com/w3c/webcrypto/issues/227
 <!--#endregion:prior-discussion-->
 
 <!--#region:todo-->
@@ -144,8 +163,8 @@ The following is a high-level list of tasks to progress through each stage of th
 
 ### Stage 2 Entrance Criteria
 
-* [ ] [Initial specification text][Specification].  
-* [ ] [Transpiler support][Transpiler] (_Optional_).  
+* [x] [Initial specification text][Specification].  
+* [ ] ~~[Transpiler support][Transpiler] (_Optional_).~~  
 
 ### Stage 3 Entrance Criteria
 
@@ -168,6 +187,7 @@ The following is a high-level list of tasks to progress through each stage of th
 [Prose]: #motivations
 [Examples]: #examples
 [API]: #api
+[TODO]: #todo
 [Specification]: #todo
 [Transpiler]: #todo
 [Stage3ReviewerSignOff]: #todo
@@ -176,3 +196,5 @@ The following is a high-level list of tasks to progress through each stage of th
 [Implementation1]: #todo
 [Implementation2]: #todo
 [Ecma262PullRequest]: #todo
+[WebCrypto]: https://w3c.github.io/webcrypto/
+[UUID]: https://github.com/tc39/proposal-uuid

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,8 +1,23 @@
 <!doctype html>
 <head><meta charset="utf-8">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-<link rel="spec" href="es2015">
-<title>Cryptographically Secure Pseudo-Random Number Generation for ECMAScript</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-intro","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"<no location>","location":"","referencingIds":[],"key":"Introduction"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"<no location>","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
+<link rel="spec" href="es2019">
+<style>
+  #metadata-block {
+    margin: 4em 0;
+    padding: 10px;
+    border: 1px solid #ee8421;
+  }
+  #metadata-block h1 {
+    font-size: 1.5em;
+    margin-top: 0;
+  }
+  #metadata-block > ul {
+    list-style-type: none;
+    margin: 0; padding: 0;
+  }
+</style>
+<title>Cryptographically Secure Pseudo-Random Number Generation for ECMAScript</title><script type="application/json" id="menu-search-biblio">[{"type":"table","id":"table-7","number":1,"caption":"Table 1: Well-Known Intrinsic Objects","referencingIds":[],"namespace":"<no location>","location":"","key":"Table 1: Well-Known Intrinsic Objects"},{"type":"clause","id":"sec-well-known-intrinsic-objects","aoid":null,"title":"Well-Known Intrinsic Objects","titleHTML":"Well-Known Intrinsic Objects","number":"1","namespace":"<no location>","location":"","referencingIds":[],"key":"Well-Known Intrinsic Objects"},{"type":"term","term":"crypto","refId":"sec-crypto-object","referencingIds":[],"namespace":"<no location>","location":"","key":"crypto"},{"type":"term","term":"%crypto%","refId":"sec-crypto-object","referencingIds":[],"namespace":"<no location>","location":"","key":"%crypto%"},{"type":"term","term":"%CryptoPrototype%","refId":"sec-%cryptoprototype%-object","referencingIds":[],"namespace":"<no location>","location":"","key":"%CryptoPrototype%"},{"type":"clause","id":"sec-%cryptoprototype%-object","aoid":null,"title":"The %CryptoPrototype% Object","titleHTML":"The %CryptoPrototype% Object","number":"2.1.1","namespace":"<no location>","location":"","referencingIds":["_ref_1","_ref_3","_ref_4"],"key":"The %CryptoPrototype% Object"},{"type":"clause","id":"sec-%cryptoprototype%-getrandomvalues","aoid":null,"title":"%CryptoPrototype%.getRandomValues ( array )","titleHTML":"%CryptoPrototype%.getRandomValues ( <var>array</var> )","number":"2.1.2","namespace":"<no location>","location":"","referencingIds":[],"key":"%CryptoPrototype%.getRandomValues ( array )"},{"type":"clause","id":"sec-%cryptoprototype%-@@tostringtag","aoid":null,"title":"%CryptoPrototype% [ @@toStringTag ]","titleHTML":"%CryptoPrototype% [ @@toStringTag ]","number":"2.1.3","namespace":"<no location>","location":"","referencingIds":[],"key":"%CryptoPrototype% [ @@toStringTag ]"},{"type":"clause","id":"sec-crypto-object","aoid":null,"title":"The crypto Object","titleHTML":"<ins>The crypto Object</ins>","number":"2.1","namespace":"<no location>","location":"","referencingIds":["_ref_0","_ref_2"],"key":"The crypto Object"},{"type":"clause","id":"sec-structured-data","aoid":null,"title":"Structured Data","titleHTML":"Structured Data","number":"2","namespace":"<no location>","location":"","referencingIds":[],"key":"Structured Data"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"<no location>","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
 
 function Search(menu) {
   this.menu = menu;
@@ -1819,15 +1834,152 @@ li.menu-search-result-term:before {
     display: none; 
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intro" title="Introduction">Introduction</a></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 1 Draft / February 6, 2020</h1><h1 class="title">Cryptographically Secure Pseudo-Random Number Generation for ECMAScript</h1>
+</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-well-known-intrinsic-objects" title="Well-Known Intrinsic Objects"><span class="secnum">1</span> Well-Known Intrinsic Objects</a></li><li><span class="item-toggle">◢</span><a href="#sec-structured-data" title="Structured Data"><span class="secnum">2</span> Structured Data</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-crypto-object" title="The crypto Object"><span class="secnum">2.1</span> <ins>The crypto Object</ins></a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-%cryptoprototype%-object" title="The %CryptoPrototype% Object"><span class="secnum">2.1.1</span> The %CryptoPrototype% Object</a></li><li><span class="item-toggle-none"></span><a href="#sec-%cryptoprototype%-getrandomvalues" title="%CryptoPrototype%.getRandomValues ( array )"><span class="secnum">2.1.2</span> %CryptoPrototype%.getRandomValues ( <var>array</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-%cryptoprototype%-@@tostringtag" title="%CryptoPrototype% [ @@toStringTag ]"><span class="secnum">2.1.3</span> %CryptoPrototype% [ @@toStringTag ]</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 1 Draft / February 6, 2020</h1><h1 class="title">Cryptographically Secure Pseudo-Random Number Generation for ECMAScript</h1>
 
-<emu-intro id="sec-intro">
-  <h1>Introduction</h1>
-  <p>Forthcoming</p>
-  <p>See  <a href="https://github.com/rbuckton/proposal-arraybuffer-fillrandom#readme">the proposal repository</a> for background material and discussion.</p>
-</emu-intro>
+<div id="metadata-block">
+  <h1>Contributing to this Proposal</h1>
+  <p>This proposal is developed on GitHub with the help of the ECMAScript community. There are a number of ways to contribute to the development of this specification:</p>
+  <ul>
+    <li>GitHub Repository:  <a href="https://github.com/tc39/proposal-csprng">https://github.com/tc39/proposal-csprng</a></li>
+    <li>Issues:  <a href="https://github.com/tc39/proposal-csprng/issues">All Issues</a>,  <a href="https://github.com/tc39/proposal-csprng/issues/new">File a New Issue</a></li>
+    <li>Pull Requests:  <a href="https://github.com/tc39/proposal-csprng/pulls">All Pull Requests</a>,  <a href="https://github.com/tc39/proposal-csprng/pulls/new">Create a New Pull Request</a></li>
+    <!-- <li>Test Suite: <a href="https://github.com/tc39/test262">Test262</a></li> -->
+    <li>
+      <p>Community:</p>
+      <ul>
+        <li>Discourse:  <a href="https://es.discourse.group">https://es.discourse.group</a></li>
+        <li>IRC:  <a href="ircs://irc.freenode.net:6667">#tc39</a> on  <a href="https://freenode.net/kb/answer/chat">freenode</a></li>
+      </ul>
+    </li>
+  </ul>
+</div>
 
-<emu-annex id="sec-copyright-and-software-license">
+<emu-import href="sec-well-known-intrinsic-objects-patch.html"><emu-clause id="sec-well-known-intrinsic-objects">
+  <h1><span class="secnum">1</span> Well-Known Intrinsic Objects</h1>
+  <emu-table id="table-7" caption="Well-Known Intrinsic Objects"><figure><figcaption>Table 1: Well-Known Intrinsic Objects</figcaption>
+    <table>
+      <tbody>
+      <tr>
+        <th>
+          Intrinsic Name
+        
+        </th>
+        <th>
+          Global Name
+        
+        </th>
+        <th>
+          ECMAScript Language Association
+        
+        </th>
+      </tr>
+      <tr>
+        <td>
+          <ins><emu-xref href="#sec-crypto-object" id="_ref_2"><a href="#sec-crypto-object">%crypto%</a></emu-xref></ins>
+        </td>
+        <td>
+          <ins><code>crypto</code></ins>
+        </td>
+        <td>
+          <ins>The <code>crypto</code> object (<emu-xref href="#sec-crypto-object" id="_ref_0"><a href="#sec-crypto-object">2.1</a></emu-xref>).</ins>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <ins><emu-xref href="#sec-%cryptoprototype%-object" id="_ref_3"><a href="#sec-%cryptoprototype%-object">%CryptoPrototype%</a></emu-xref></ins>
+        </td>
+        <td>
+        </td>
+        <td>
+          <ins>The prototype of the <code>crypto</code> object (<emu-xref href="#sec-%cryptoprototype%-object" id="_ref_1"><a href="#sec-%cryptoprototype%-object">2.1.1</a></emu-xref>). Intended for compatibility with the  <a href="https://w3c.github.io/webcrypto">Web Cryptography API</a>.</ins>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </figure></emu-table>
+</emu-clause></emu-import>
+<emu-import href="sec-structured-data-patch.html"><emu-clause id="sec-structured-data">
+  <h1><span class="secnum">2</span> Structured Data</h1>
+  <emu-clause id="sec-crypto-object">
+    <h1><span class="secnum">2.1</span> <ins>The crypto Object</ins></h1>
+    <p>The  <dfn>crypto</dfn> object:</p>
+    <li>is the intrinsic object  <dfn>%crypto%</dfn>.
+    
+    </li><li>is the initial value of the <emu-val>"crypto"</emu-val> property of the <emu-xref href="#global-object"><a href="https://tc39.github.io/ecma262/#global-object">global object</a></emu-xref>.
+    
+    </li><li>is an ordinary object.
+    
+    </li><li>has a [[Prototype]] internal slot whose value is <emu-xref href="#sec-%cryptoprototype%-object" id="_ref_4"><a href="#sec-%cryptoprototype%-object">%CryptoPrototype%</a></emu-xref>.
+    
+    </li><li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the <code>new</code> operator.
+    
+    </li><li>does not have a [[Call]] internal method; it cannot be invoked as a function.
+    
+    <emu-clause id="sec-%cryptoprototype%-object">
+      <h1><span class="secnum">2.1.1</span> The %CryptoPrototype% Object</h1>
+      <p>The  <dfn>%CryptoPrototype%</dfn> object:</p>
+      </emu-clause></li><li>has a [[Prototype]] internal slot whose value is %Object.prototype%.
+      
+      </li><li>is an ordinary object.
+      
+      <emu-clause id="sec-%cryptoprototype%-getrandomvalues">
+        <h1><span class="secnum">2.1.2</span> %CryptoPrototype%.getRandomValues ( <var>array</var> )</h1>
+        <emu-alg><ol><li>Perform ?&nbsp;RequireInternalSlot(<var>array</var>, [[TypedArrayName]]).</li><li>Assert: <var>array</var> has the [[ViewedArrayBuffer]], [[ByteLength]], and [[ByteOffset\]\] internal slots.</li><li>If <var>array</var>.[[TypedArrayName]] is not one of <code>"Int8Array"</code>, <code>"Uint8Array"</code>, <code>"Uint8ClampedArray"</code>, <code>"Int16Array"</code>,
+             <code>"Uint16Array"</code>, <code>"Int32Array"</code>, <code>"Uint32Array"</code>, <code>"BigInt64Array"</code>, or <code>"BigUint64Array"</code>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>buffer</var> be <var>array</var>.[[ViewedArrayBuffer]].</li><li>If !&nbsp;<emu-xref aoid="IsDetachedBuffer" id="_ref_5"><a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">IsDetachedBuffer</a></emu-xref>(<var>buffer</var>) is <emu-const>true</emu-const>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>byteLength</var> be <var>array</var>.[[ByteLength]].</li><li>If <var>byteLength</var> is greater than 65536, throw a <emu-val>RangeError</emu-val> exception.</li><li>Let <var>byteOffset</var> be <var>array</var>.[[ByteOffset]].</li><li>Let <var>byteEndOffset</var> be <var>byteOffset</var> + <var>byteLength</var>.</li><li>Overwrite the elements of <var>buffer</var> from index <var>byteOffset</var> (inclusive) through index <var>byteEndOffset</var> (exclusive)
+             with cryptographically secure random values.</li><li>Return <var>array</var>.
+        </li></ol></emu-alg>
+        <emu-note><span class="note">Note 1</span><div class="note-contents">
+          <p>
+          Implementations should generate cryptographically secure random values using well-established cryptographic
+          pseudo-random number generators seeded with high-quality entropy, such as from an operating-system entropy
+          source (e.g., "/dev/urandom"). This specification provides no lower-bound on the information theoretic entropy
+          present in cryptographically secure random values, but implementations should make a best effort to provide as
+          much entropy as practicable.
+          
+          </p>
+        </div></emu-note>
+        <emu-note><span class="note">Note 2</span><div class="note-contents">
+          <p>
+          This interface defines a synchronous method for obtaining cryptographically secure random values. While some 
+          devices and implementations may support truly random cryptographic number generators or provide interfaces that 
+          block when there is insufficient entropy, implementations are discouraged from using these sources when 
+          implementing getRandomValues, both for performance and to avoid depleting the system of entropy. Instead, these 
+          sources should be used to seed a cryptographic pseudo-random number generator that can then return suitable 
+          values efficiently.
+          
+          </p>
+        </div></emu-note>
+        <emu-note><span class="note">Note 3</span><div class="note-contents">
+          <p>
+          The above algorithm and notes were derived from  <a href="https://w3c.github.io/webcrypto/#Crypto-description">relevant sections</a>
+          of the  <a href="https://w3c.github.io/webcrypto/">Web Cryptography API</a> with the intent to preserve algorithm compatibility 
+          between the two implementations.
+          
+          </p>
+          <p>
+          The  <a href="https://w3c.github.io/webcrypto/">Web Cryptography API</a> is 
+          Copyright © 2018  <a href="http://www.w3.org/">World Wide Web Consortium</a>, (<a href="http://www.csail.mit.edu/">MIT</a>, 
+           
+          <a href="http://www.ercim.org/">ERCIM</a>,  <a href="http://www.keio.ac.jp/">Keio</a>,  <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
+           
+          <a href="http://www.w3.org/Consortium/Legal/2015/doc-license">http://www.w3.org/Consortium/Legal/2015/doc-license</a>
+          </p>
+          <p>
+          The  <a href="https://w3c.github.io/webcrypto/">Web Cryptography API</a> is an Editors Draft, per the 
+           
+          <a href="https://www.w3.org/2018/Process-20180201/">1 February 2018 W3C Process Document</a>.
+          
+          </p>
+        </div></emu-note>
+      </emu-clause>
+      <emu-clause id="sec-%cryptoprototype%-@@tostringtag">
+        <h1><span class="secnum">2.1.3</span> %CryptoPrototype% [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value <emu-val>"Crypto"</emu-val>.</p>
+        <p>This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
+      </emu-clause>
+    
+  
+</li></emu-clause></emu-clause><emu-annex id="sec-copyright-and-software-license">
       <h1><span class="secnum">A</span> Copyright &amp; Software License</h1>
       
       <h2>Copyright Notice</h2>
@@ -1846,4 +1998,5 @@ li.menu-search-result-term:before {
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex></div></body>
+    </emu-annex></emu-import>
+</div></body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1565,9 +1565,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
-      "integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "proposal-arraybuffer-fillrandom",
+  "name": "proposal-csprng",
   "version": "0.0.0",
   "private": true,
-  "description": "ArrayBuffer.fillRandom - CSRNG for ECMAScript",
+  "description": "Cryptographically Secure Pseudo-Random Number Generation for ECMAScript",
   "homepage": "https://github.com/rbuckton/proposal-arraybuffer-fillrandom#readme",
   "author": {
     "name": "Ron Buckton",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "license": "SEE LICENSE IN https://tc39.github.io/ecma262/#sec-copyright-and-software-license",
   "devDependencies": {
-    "ecmarkup": "^3.16.0",
     "del": "^5.0.0",
+    "ecmarkup": "^3.17.0",
     "gulp": "^4.0.2",
     "gulp-emu": "^1.2.0",
     "gulp-live-server": "^0.0.31"

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,16 +1,45 @@
 <!doctype html>
 <meta charset="utf8">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-<link rel="spec" href="es2015" />
+<link rel="spec" href="es2019" />
+<style>
+  #metadata-block {
+    margin: 4em 0;
+    padding: 10px;
+    border: 1px solid #ee8421;
+  }
+  #metadata-block h1 {
+    font-size: 1.5em;
+    margin-top: 0;
+  }
+  #metadata-block > ul {
+    list-style-type: none;
+    margin: 0; padding: 0;
+  }
+</style>
 <pre class="metadata">
 title: Cryptographically Secure Pseudo-Random Number Generation for ECMAScript
 stage: 1
 contributors: Ron Buckton, Ecma International
 </pre>
 
-<emu-intro id="sec-intro">
-  <h1>Introduction</h1>
-  <p>Forthcoming</p>
-  <p>See <a href="https://github.com/rbuckton/proposal-arraybuffer-fillrandom#readme">the proposal repository</a> for background material and discussion.</p>
-</emu-intro>
+<div id="metadata-block">
+  <h1>Contributing to this Proposal</h1>
+  <p>This proposal is developed on GitHub with the help of the ECMAScript community. There are a number of ways to contribute to the development of this specification:</p>
+  <ul>
+    <li>GitHub Repository: <a href="https://github.com/tc39/proposal-csprng">https://github.com/tc39/proposal-csprng</a></li>
+    <li>Issues: <a href="https://github.com/tc39/proposal-csprng/issues">All Issues</a>, <a href="https://github.com/tc39/proposal-csprng/issues/new">File a New Issue</a></li>
+    <li>Pull Requests: <a href="https://github.com/tc39/proposal-csprng/pulls">All Pull Requests</a>, <a href="https://github.com/tc39/proposal-csprng/pulls/new">Create a New Pull Request</a></li>
+    <!-- <li>Test Suite: <a href="https://github.com/tc39/test262">Test262</a></li> -->
+    <li>
+      <p>Community:</p>
+      <ul>
+        <li>Discourse: <a href="https://es.discourse.group">https://es.discourse.group</a></li>
+        <li>IRC: <a href="ircs://irc.freenode.net:6667">#tc39</a> on <a href="https://freenode.net/kb/answer/chat">freenode</a></li>
+      </ul>
+    </li>
+  </ul>
+</div>
 
+<emu-import href="sec-well-known-intrinsic-objects-patch.html"></emu-import>
+<emu-import href="sec-structured-data-patch.html"></emu-import>

--- a/spec/sec-structured-data-patch.html
+++ b/spec/sec-structured-data-patch.html
@@ -1,0 +1,78 @@
+<emu-clause id="sec-structured-data">
+  <h1>Structured Data</h1>
+  <emu-clause id="sec-crypto-object">
+    <h1><ins>The crypto Object</ins></h1>
+    <p>The <dfn>crypto</dfn> object:</p>
+    <li>is the intrinsic object <dfn>%crypto%</dfn>.
+    <li>is the initial value of the *"crypto"* property of the global object.
+    <li>is an ordinary object.
+    <li>has a [[Prototype]] internal slot whose value is %CryptoPrototype%.
+    <li>does not have a [[Construct]] internal method; it cannot be used as a constructor with the `new` operator.
+    <li>does not have a [[Call]] internal method; it cannot be invoked as a function.
+    <emu-clause id="sec-%cryptoprototype%-object">
+      <h1>The %CryptoPrototype% Object</h1>
+      <p>The <dfn>%CryptoPrototype%</dfn> object:</p>
+      <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.
+      <li>is an ordinary object.
+      <emu-clause id="sec-%cryptoprototype%-getrandomvalues">
+        <h1>%CryptoPrototype%.getRandomValues ( _array_ )</h1>
+        <emu-alg>
+          1. Perform ? RequireInternalSlot(_array_, [[TypedArrayName]]).
+          1. Assert: _array_ has the [[ViewedArrayBuffer]], [[ByteLength]], and [[ByteOffset\]\] internal slots.
+          1. If _array_.[[TypedArrayName]] is not one of `"Int8Array"`, `"Uint8Array"`, `"Uint8ClampedArray"`, `"Int16Array"`,
+             `"Uint16Array"`, `"Int32Array"`, `"Uint32Array"`, `"BigInt64Array"`, or `"BigUint64Array"`, throw a *TypeError* exception.
+          1. Let _buffer_ be _array_.[[ViewedArrayBuffer]].
+          1. If ! IsDetachedBuffer(_buffer_) is ~true~, throw a *TypeError* exception.
+          1. Let _byteLength_ be _array_.[[ByteLength]].
+          1. If _byteLength_ is greater than 65536, throw a *RangeError* exception.
+          1. Let _byteOffset_ be _array_.[[ByteOffset]].
+          1. Let _byteEndOffset_ be _byteOffset_ + _byteLength_.
+          1. Overwrite the elements of _buffer_ from index _byteOffset_ (inclusive) through index _byteEndOffset_ (exclusive)
+             with cryptographically secure random values.
+          1. Return _array_.
+        </emu-alg>
+        <emu-note>
+          <p>
+          Implementations should generate cryptographically secure random values using well-established cryptographic
+          pseudo-random number generators seeded with high-quality entropy, such as from an operating-system entropy
+          source (e.g., "/dev/urandom"). This specification provides no lower-bound on the information theoretic entropy
+          present in cryptographically secure random values, but implementations should make a best effort to provide as
+          much entropy as practicable.
+          </p>
+        </emu-note>
+        <emu-note>
+          <p>
+          This interface defines a synchronous method for obtaining cryptographically secure random values. While some 
+          devices and implementations may support truly random cryptographic number generators or provide interfaces that 
+          block when there is insufficient entropy, implementations are discouraged from using these sources when 
+          implementing getRandomValues, both for performance and to avoid depleting the system of entropy. Instead, these 
+          sources should be used to seed a cryptographic pseudo-random number generator that can then return suitable 
+          values efficiently.
+          </p>
+        </emu-note>
+        <emu-note>
+          <p>
+          The above algorithm and notes were derived from <a href="https://w3c.github.io/webcrypto/#Crypto-description">relevant sections</a>
+          of the <a href="https://w3c.github.io/webcrypto/">Web Cryptography API</a> with the intent to preserve algorithm compatibility 
+          between the two implementations.
+          </p>
+          <p>
+          The <a href="https://w3c.github.io/webcrypto/">Web Cryptography API</a> is 
+          Copyright &#xA9; 2018 <a href="http://www.w3.org/">World Wide Web Consortium</a>, (<a href="http://www.csail.mit.edu/">MIT</a>, 
+          <a href="http://www.ercim.org/">ERCIM</a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
+          <a href="http://www.w3.org/Consortium/Legal/2015/doc-license">http://www.w3.org/Consortium/Legal/2015/doc-license</a>
+          </p>
+          <p>
+          The <a href="https://w3c.github.io/webcrypto/">Web Cryptography API</a> is an Editors Draft, per the 
+          <a href="https://www.w3.org/2018/Process-20180201/">1 February 2018 W3C Process Document</a>.
+          </p>
+        </emu-note>
+      </emu-clause>
+      <emu-clause id="sec-%cryptoprototype%-@@tostringtag">
+        <h1>%CryptoPrototype% [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value *"Crypto"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>

--- a/spec/sec-well-known-intrinsic-objects-patch.html
+++ b/spec/sec-well-known-intrinsic-objects-patch.html
@@ -1,0 +1,41 @@
+<emu-clause id="sec-well-known-intrinsic-objects">
+  <h1>Well-Known Intrinsic Objects</h1>
+  <emu-table id="table-7" caption="Well-Known Intrinsic Objects">
+    <table>
+      <tbody>
+      <tr>
+        <th>
+          Intrinsic Name
+        </th>
+        <th>
+          Global Name
+        </th>
+        <th>
+          ECMAScript Language Association
+        </th>
+      </tr>
+      <tr>
+        <td>
+          <ins>%crypto%</ins>
+        </td>
+        <td>
+          <ins>`crypto`</ins>
+        </td>
+        <td>
+          <ins>The `crypto` object (<emu-xref href="#sec-crypto-object"></emu-xref>).</ins>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <ins>%CryptoPrototype%</ins>
+        </td>
+        <td>
+        </td>
+        <td>
+          <ins>The prototype of the `crypto` object (<emu-xref href="#sec-%cryptoprototype%-object"></emu-xref>). Intended for compatibility with the <a href="https://w3c.github.io/webcrypto">Web Cryptography API</a>.</ins>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </emu-table>
+</emu-clause>


### PR DESCRIPTION
This Draft PR is intended to explore the possibility of devising a `crypto` global that would be compatible with the [Web Cryptography API](https://w3c.github.io/webcrypto/), such that web hosts could extend the API to encompass the full Web Cryptography API without issues with compatibility.